### PR TITLE
Add beginning of Prompts

### DIFF
--- a/app/Http/Controllers/Twill/ThemeController.php
+++ b/app/Http/Controllers/Twill/ThemeController.php
@@ -10,6 +10,7 @@ use A17\Twill\Services\Forms\Fieldset;
 use A17\Twill\Services\Forms\Fieldsets;
 use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Image;
+use A17\Twill\Services\Listings\Columns\NestedData;
 use A17\Twill\Services\Listings\TableColumns;
 
 class ThemeController extends BaseModuleController
@@ -85,6 +86,17 @@ class ThemeController extends BaseModuleController
         $table->splice(1, 0, [
             Image::make()->field('icon'),
         ]);
+
+        return $table;
+    }
+
+    protected function additionalIndexTableColumns(): TableColumns
+    {
+        $table = parent::additionalIndexTableColumns();
+
+        $table->add(
+            NestedData::make()->field('prompts')
+        );
 
         return $table;
     }

--- a/app/Http/Controllers/Twill/ThemePromptController.php
+++ b/app/Http/Controllers/Twill/ThemePromptController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Twill;
+
+use A17\Twill\Http\Controllers\Admin\ModuleController as BaseModuleController;
+use A17\Twill\Models\Contracts\TwillModelContract;
+use A17\Twill\Services\Breadcrumbs\NestedBreadcrumbs;
+use A17\Twill\Services\Forms\Fields\Input;
+use A17\Twill\Services\Forms\Form;
+use App\Repositories\ThemeRepository;
+
+class ThemePromptController extends BaseModuleController
+{
+    protected $moduleName = 'themes.prompts';
+
+    protected $modelName = 'ThemePrompt';
+
+    protected function setUpController(): void
+    {
+        $this->disablePermalink();
+
+        if (request('theme')) {
+            $this->setBreadcrumbs(
+                NestedBreadcrumbs::make()
+                    ->forParent(
+                        parentModule: 'themes',
+                        module: $this->moduleName,
+                        activeParentId: request('theme'),
+                        repository: ThemeRepository::class
+                    )
+                    ->label('Prompts')
+            );
+        }
+    }
+
+    public function getForm(TwillModelContract $model): Form
+    {
+        $form = parent::getForm($model);
+
+        $form->add(
+            Input::make()->name('subtitle')->label('Subtitle')->translatable()
+        );
+
+        return $form;
+    }
+}

--- a/app/Http/Requests/Twill/ThemePromptRequest.php
+++ b/app/Http/Requests/Twill/ThemePromptRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Twill;
+
+use A17\Twill\Http\Requests\Admin\Request;
+
+class ThemePromptRequest extends Request
+{
+    public function rulesForCreate()
+    {
+        return [];
+    }
+
+    public function rulesForUpdate()
+    {
+        return [];
+    }
+}

--- a/app/Models/Revisions/ThemePromptRevision.php
+++ b/app/Models/Revisions/ThemePromptRevision.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models\Revisions;
+
+use A17\Twill\Models\Revision;
+
+class ThemePromptRevision extends Revision
+{
+    protected $table = 'theme_prompt_revisions';
+}

--- a/app/Models/Theme.php
+++ b/app/Models/Theme.php
@@ -76,4 +76,9 @@ class Theme extends Model implements Sortable
             ],
         ],
     ];
+
+    public function prompts()
+    {
+        return $this->hasMany(ThemePrompt::class);
+    }
 }

--- a/app/Models/ThemePrompt.php
+++ b/app/Models/ThemePrompt.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use A17\Twill\Models\Behaviors\HasPosition;
+use A17\Twill\Models\Behaviors\HasRevisions;
+use A17\Twill\Models\Behaviors\HasTranslation;
+use A17\Twill\Models\Behaviors\Sortable;
+use A17\Twill\Models\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class ThemePrompt extends Model implements Sortable
+{
+    use HasFactory, HasPosition, HasRevisions, HasTranslation;
+
+    protected $fillable = [
+        'published',
+        'title',
+        'subtitle',
+        'position',
+        'theme_id',
+    ];
+
+    public $translatedAttributes = [
+        'title',
+        'subtitle',
+    ];
+
+    public function theme()
+    {
+        return $this->belongsTo(Theme::class);
+    }
+}

--- a/app/Models/Translations/ThemePromptTranslation.php
+++ b/app/Models/Translations/ThemePromptTranslation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models\Translations;
+
+use A17\Twill\Models\Model;
+use App\Models\ThemePrompt;
+
+class ThemePromptTranslation extends Model
+{
+    protected $baseModuleModel = ThemePrompt::class;
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -26,6 +26,7 @@ class AppServiceProvider extends ServiceProvider
 
         Relation::enforceMorphMap([
             'theme' => 'App\Models\Theme',
+            'theme_prompt' => 'App\Models\ThemePrompt',
         ]);
 
         TwillNavigation::addLink(

--- a/app/Repositories/ThemePromptRepository.php
+++ b/app/Repositories/ThemePromptRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repositories;
+
+use A17\Twill\Repositories\Behaviors\HandleRevisions;
+use A17\Twill\Repositories\Behaviors\HandleTranslations;
+use A17\Twill\Repositories\ModuleRepository;
+use App\Models\ThemePrompt;
+
+class ThemePromptRepository extends ModuleRepository
+{
+    use HandleRevisions, HandleTranslations;
+
+    public function __construct(ThemePrompt $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/database/factories/ThemePromptFactory.php
+++ b/database/factories/ThemePromptFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ThemePrompt>
+ */
+class ThemePromptFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/migrations/2024_04_04_173834_create_theme_prompts_tables.php
+++ b/database/migrations/2024_04_04_173834_create_theme_prompts_tables.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Theme;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('theme_prompts', function (Blueprint $table) {
+            createDefaultTableFields($table);
+
+            $table->integer('position')->unsigned()->nullable();
+
+            $table->foreignIdFor(Theme::class);
+        });
+
+        Schema::create('theme_prompt_translations', function (Blueprint $table) {
+            createDefaultTranslationsTableFields($table, 'theme_prompt');
+            $table->string('title', 200)->nullable();
+            $table->text('subtitle')->nullable();
+        });
+
+        Schema::create('theme_prompt_revisions', function (Blueprint $table) {
+            createDefaultRevisionsTableFields($table, 'theme_prompt');
+        });
+    }
+};

--- a/resources/views/site/themePrompt.blade.php
+++ b/resources/views/site/themePrompt.blade.php
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <title>Demo page</title>
+</head>
+<body>
+<div>
+    Example preview. See <a href="https://twillcms.com/docs/modules/revisions-and-previewing.html">documentation.</a>
+    <br />
+    {{ $item->title }}
+    <br />
+    {{ $item->subtitle }}
+</div>
+</body>
+</html>

--- a/routes/twill.php
+++ b/routes/twill.php
@@ -3,3 +3,4 @@
 use A17\Twill\Facades\TwillRoutes;
 
 TwillRoutes::module('themes');
+TwillRoutes::module('themes.prompts');


### PR DESCRIPTION
This PR starts the process of adding Prompts.

Prompts have been added as a [parent-child](https://twillcms.com/docs/modules/nested-modules.html#content-parent-child-modules) module under Themes.  

After Artwork is added Prompts will be updated to allow attaching and managing artwork for each prompt.

![Capture-2024-04-11-094104](https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/9a3b3a7a-cd58-447d-8104-5bd72938db50)

--- 

<img width="1399" alt="Screenshot 2024-04-11 at 9 41 26 AM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/b4ee8092-8dff-4e70-b2af-30feed0d00d4">

---

<img width="1383" alt="Screenshot 2024-04-11 at 9 41 37 AM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/fbea8407-f606-43dc-92a1-de34d0f44f29">

---

<img width="713" alt="Screenshot 2024-04-11 at 9 41 49 AM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/bb78b40a-4f94-4b21-abcc-d1f97a393fa4">