### PR TITLE
Update credit_line to support more text

### DIFF
--- a/database/migrations/2024_04_08_164938_create_artworks_tables.php
+++ b/database/migrations/2024_04_08_164938_create_artworks_tables.php
@@ -13,7 +13,7 @@ return new class extends Migration
             $table->string('datahub_id');
             $table->string('main_reference_number')->nullable();
             $table->boolean('is_on_view')->nullable();
-            $table->string('credit_line')->nullable();
+            $table->text('credit_line')->nullable();
             $table->string('copyright_notice')->nullable();
             $table->decimal('latitude', 15, 13)->nullable();
             $table->decimal('longitude', 16, 13)->nullable();


### PR DESCRIPTION
This PR updates the `credit_line` column to allow more text and fix an issue with seeding the staging environment. 

```
      Database\Seeders\ArtworkSeeder ..................................... RUNNING
  
    In Connection.php line 829:
  
      SQLSTATE[22001]: String data, right truncated: 1406 Data too long for colum
      n 'credit_line' at row 1 (Connection: mysql, SQL: insert into `artworks` (`
      latitude`, `longitude`, `floor`, `gallery_id`, `position`, `published`, `da
      tahub_id`, `main_reference_number`, `credit_line`, `copyright_notice`, `is_
      on_view`, `image_id`, `updated_at`, `created_at`) values (0, 0, ?, ?, 15, 1
      , 209926, 2011.247, Through prior purchase of the Grant J. Pick purchase fu
      nd; through prior bequest of Sigmund E. Edelstone; Frederick W. Renshaw Acq
      uisition fund; Estate of Walter Aitken; Alyce and Edwin DeCosta, Walter E.
      Heller Foundation, and Ada Turnbull Hertle funds; Wirt D. Walker Trust;  Ma
      rian and Samuel Klasstorner, Mrs. Clive Runnells, Alfred and May Tiefenbron
      ner Memorial, Boles C. and Hyacinth G. Drechney, Charles H. and Mary F. Wor
      cester Collection,Mary and Leigh Block Endowment, Gladys N. Anderson, Benja
      min Argile Memorial, Director's, and Joyce Van Pilsum funds., © Robert Raus
      chenberg Foundation., 0, 42f73a1b-0653-0cc2-f35f-bc92cf40c5ba, 2024-04-19 1
      9:30:12, 2024-04-19 19:30:12))
  
  
    In Connection.php line 587:
  
      SQLSTATE[22001]: String data, right truncated: 1406 Data too long for colum
      n 'credit_line' at row 1
  stdout_lines: <omitted>
```