### PR TITLE
Cache JSON output

### DIFF
--- a/app/Console/Commands/CacheJsonCommand.php
+++ b/app/Console/Commands/CacheJsonCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Http\Resources\ThemeResource;
+use App\Models\ActivityTemplate;
+use App\Models\Artwork;
+use App\Repositories\ThemeRepository;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Cache;
+
+class CacheJsonCommand extends Command
+{
+    protected $signature = 'app:cache-json {id?}';
+
+    protected $description = 'Cache JSON data for for the front-end.';
+
+    public function __construct(
+        private readonly ThemeRepository $themeRepository
+    ) {
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        Artwork::cacheArtworkApiData();
+
+        collect([
+            'data.json' => 'en',
+            'data-es.json' => 'es',
+            'data-zh-hans.json' => 'zh',
+        ])
+            ->when($this->argument('id'), fn ($collection) => $collection->only($this->argument('id')))
+            ->each(function ($locale, $key) {
+                App::setLocale($locale);
+
+                $data = [
+                    'activityTemplates' => ActivityTemplate::select('id', 'img')->get(),
+                    'themes' => ThemeResource::collection(
+                        $this->themeRepository->active()->with(
+                            [
+                                'prompts' => fn (Builder $query) => $query->active(),
+                                'prompts.artworks' => fn (Builder $query) => $query->active()->limit(8),
+                            ]
+                        )->get()
+                    ),
+                ];
+
+                Cache::put($key, json_encode($data));
+            });
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,7 +12,10 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        $schedule->command('app:cache-json')->everyFiveMinutes();
+        $schedule
+            ->command('app:cache-json')
+            ->everyFiveMinutes()
+            ->withoutOverlapping();
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,7 +12,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->command('app:cache-json')->everyFiveMinutes();
     }
 
     /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,4 +7,4 @@ Route::get('/', function () {
     return redirect('/admin');
 });
 
-Route::get('/json/{id}.json', JsonController::class);
+Route::get('/json/{id}', JsonController::class);

--- a/tests/Feature/JsonDataTest.php
+++ b/tests/Feature/JsonDataTest.php
@@ -7,6 +7,7 @@ use App\Models\Artwork;
 use App\Models\Theme;
 use App\Models\ThemePrompt;
 use Database\Seeders\TestSeeder;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Illuminate\Testing\Fluent\AssertableJson;
 use PHPUnit\Framework\Attributes\Test;
@@ -230,6 +231,8 @@ class JsonDataTest extends TestCase
 
         Theme::find(1)->update(['published' => false]);
 
+        Cache::forget('data.json');
+
         $this->get('/json/data.json')
             ->assertJsonCount(3, 'themes');
     }
@@ -241,6 +244,8 @@ class JsonDataTest extends TestCase
             ->assertJsonCount(4, 'themes.0.prompts');
 
         ThemePrompt::find(1)->update(['published' => false]);
+
+        Cache::forget('data.json');
 
         $this->get('/json/data.json')
             ->assertJsonCount(3, 'themes.0.prompts');
@@ -259,6 +264,8 @@ class JsonDataTest extends TestCase
         $visibleArtworks->take(8 - $visibleArtworks->count() - 1)
             ->each(fn ($artwork) => $artwork->update(['published' => false]));
 
+        Cache::forget('data.json');
+
         $this->get('/json/data.json')
             ->assertJsonCount(7, 'themes.0.prompts.0.artworks');
     }
@@ -271,6 +278,8 @@ class JsonDataTest extends TestCase
 
         Theme::find(1)->translations()->where('locale', 'es')->update(['active' => false]);
 
+        Cache::forget('data.json');
+
         $this->get('/json/data.json')
             ->assertJsonCount(3, 'themes');
     }
@@ -282,6 +291,8 @@ class JsonDataTest extends TestCase
             ->assertJsonCount(4, 'themes.0.prompts');
 
         ThemePrompt::find(1)->translations()->where('locale', 'es')->update(['active' => false]);
+
+        Cache::forget('data.json');
 
         $this->get('/json/data.json')
             ->assertJsonCount(3, 'themes.0.prompts');
@@ -302,12 +313,16 @@ class JsonDataTest extends TestCase
         $visibleArtworks->take(8 - $visibleArtworks->count() - 1)
             ->each(fn ($artwork) => $artwork->translations()->where('locale', 'es')->update(['active' => false]));
 
+        Cache::forget('data.json');
+
         $this->get('/json/data.json')
             ->assertJsonCount(7, 'themes.0.prompts.0.artworks');
 
         // Artwork also requires all translations to be active
         $themePrompt->artworks()->active()->get()->first()
             ->artwork->translations()->where('locale', 'es')->update(['active' => false]);
+
+        Cache::forget('data.json');
 
         $this->get('/json/data.json')
             ->assertJsonCount(6, 'themes.0.prompts.0.artworks');


### PR DESCRIPTION
This PR adds caching for the JSON output.

The `app:cache-json` command produces and caches the JSON data for each locale. 
Optionally you can provide a key to only produce JSON data for a single locale. 

The controller has been updated to return the cached JSON if it exists or execute the caching command for the requested locale and return the output. 

When tests expect the output to change between assertions, we need to clear this cache. 

Each JSON output is about 400kb.
Redis has a max value size of 512 MB.
Memcached has a max value size of 1MB.