### PR TITLE
Add sorting to themes and prompts

### DIFF
--- a/app/Console/Commands/CacheImageInfo.php
+++ b/app/Console/Commands/CacheImageInfo.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Libraries\DamsImageService;
+use App\Models\Artwork;
+use Illuminate\Console\Command;
+
+class CacheImageInfo extends Command
+{
+    protected $signature = 'app:cache-image-info';
+
+    protected $description = 'Caches image info required for building JSON output.';
+
+    public function __construct(
+        private readonly DamsImageService $damsImageService
+    ) {
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        $this->withProgressBar(Artwork::active()->get(), function (Artwork $artwork) {
+            $this->damsImageService->getImage($artwork);
+        });
+    }
+}

--- a/app/Console/Commands/CacheJsonCommand.php
+++ b/app/Console/Commands/CacheJsonCommand.php
@@ -42,11 +42,20 @@ class CacheJsonCommand extends Command
                         $this->themeRepository->active()->with(
                             [
                                 'prompts' => fn (Builder $query) => $query->active(),
-                                'prompts.artworks' => fn (Builder $query) => $query->active()->limit(8),
+                                'prompts.artworks' => fn (Builder $query) => $query->active(),
                             ]
                         )->get()
                     ),
                 ];
+
+                // Limit the number of artworks per prompt to 8
+                // This can be removed once we upgrade to Laravel 11
+                // https://github.com/laravel/framework/pull/49695
+                foreach ($data['themes'] as $themeKey => $theme) {
+                    foreach ($theme['prompts'] as $promptKey => $prompt) {
+                        $data['themes'][$themeKey]['prompts'][$promptKey]['artworks'] = $prompt['artworks']->take(8);
+                    }
+                }
 
                 Cache::put($key, json_encode($data));
             });

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,10 @@ class Kernel extends ConsoleKernel
             ->command('app:cache-json')
             ->everyFiveMinutes()
             ->withoutOverlapping();
+
+        $schedule
+            ->command('app:cache-image-info')
+            ->daily();
     }
 
     /**

--- a/app/Http/Controllers/Twill/ThemeController.php
+++ b/app/Http/Controllers/Twill/ThemeController.php
@@ -25,6 +25,8 @@ class ThemeController extends ModuleController
         $this->disableBulkPublish();
         $this->disableBulkRestore();
         $this->disableBulkForceDelete();
+        $this->disableSortable();
+        $this->enableReorder();
     }
 
     public function getCreateForm(): Form

--- a/app/Http/Controllers/Twill/ThemePromptController.php
+++ b/app/Http/Controllers/Twill/ThemePromptController.php
@@ -30,6 +30,8 @@ class ThemePromptController extends ModuleController
         $this->disableBulkPublish();
         $this->disableBulkRestore();
         $this->disableBulkForceDelete();
+        $this->disableSortable();
+        $this->enableReorder();
 
         if (request('theme')) {
             $this->setBreadcrumbs(

--- a/app/Models/Theme.php
+++ b/app/Models/Theme.php
@@ -91,6 +91,13 @@ class Theme extends Model implements Sortable
         ],
     ];
 
+    protected static function booted(): void
+    {
+        static::addGlobalScope('order', function (Builder $builder) {
+            $builder->orderBy('position');
+        });
+    }
+
     public function prompts()
     {
         return $this->hasMany(ThemePrompt::class);

--- a/app/Models/ThemePrompt.php
+++ b/app/Models/ThemePrompt.php
@@ -27,6 +27,13 @@ class ThemePrompt extends Model implements Sortable
         'subtitle',
     ];
 
+    protected static function booted(): void
+    {
+        static::addGlobalScope('order', function (Builder $builder) {
+            $builder->orderBy('position');
+        });
+    }
+
     public function theme()
     {
         return $this->belongsTo(Theme::class);
@@ -34,7 +41,7 @@ class ThemePrompt extends Model implements Sortable
 
     public function artworks()
     {
-        return $this->hasMany(ThemePromptArtwork::class)->orderBy('position');
+        return $this->hasMany(ThemePromptArtwork::class);
     }
 
     public function scopeActive(Builder $query): void

--- a/app/Models/ThemePromptArtwork.php
+++ b/app/Models/ThemePromptArtwork.php
@@ -31,6 +31,13 @@ class ThemePromptArtwork extends Model implements Sortable
         'activity_instructions',
     ];
 
+    protected static function booted(): void
+    {
+        static::addGlobalScope('order', function (Builder $builder) {
+            $builder->orderBy('position');
+        });
+    }
+
     public function artwork()
     {
         return $this->belongsTo(Artwork::class);

--- a/resources/views/forms/prompts.blade.php
+++ b/resources/views/forms/prompts.blade.php
@@ -7,9 +7,17 @@
 @endphp
 
 <div class="custom">
-    <ul class="py-2">
+    <ul class="py-2 text-lg">
+        <li>
+            <a
+                class="block p-2 hover:bg-slate-100"
+                href="{{ route('twill.themes.prompts.index', $theme->id) }}"
+            >
+                ALL PROMPTS
+            </a>
+        </li>
         @foreach($theme->prompts()->orderBy('position')->get() as $prompt)
-            <li class="text-lg">
+            <li>
                 <a
                     @class(['block p-2  hover:bg-slate-100', 'font-semibold' => $prompt->id == $currentPromptId])
                     href="{{ route('twill.themes.prompts.show', [$theme->id, $prompt->id]) }}"


### PR DESCRIPTION
This PR adds sorting to themes and prompts.

- Adds new `app:cache-image-info` to cache image data which will occasionally slow the generation of the cached JSON output.
- Removes the `limit(8)` when eager loading the artworks
  - This can be added back once we upgrade to Laravel 11

![2024-04-30 13 22 30](https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/02aa988c-e292-4ceb-a887-bf8f925acf1f)
![2024-04-30 13 23 02](https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/07b5b7ac-659d-4e77-b3a1-b5598ada09d4)
