### PR TITLE
Add filters to artwork

### DIFF
--- a/app/Http/Controllers/Twill/ThemeController.php
+++ b/app/Http/Controllers/Twill/ThemeController.php
@@ -12,6 +12,8 @@ use A17\Twill\Services\Forms\Fieldsets;
 use A17\Twill\Services\Forms\Form;
 use A17\Twill\Services\Listings\Columns\Image;
 use A17\Twill\Services\Listings\Columns\NestedData;
+use A17\Twill\Services\Listings\Filters\QuickFilter;
+use A17\Twill\Services\Listings\Filters\QuickFilters;
 use A17\Twill\Services\Listings\TableColumns;
 
 class ThemeController extends ModuleController
@@ -129,5 +131,15 @@ class ThemeController extends ModuleController
         );
 
         return $table;
+    }
+
+    public function quickFilters(): QuickFilters
+    {
+        return new QuickFilters([
+            QuickFilter::make()
+                ->label(twillTrans('twill::lang.listing.filter.all-items'))
+                ->queryString('all')
+                ->amount(fn () => $this->repository->getCountByStatusSlug('all')),
+        ]);
     }
 }

--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -118,9 +118,34 @@ class Artwork extends Model
 
     public function scopeActive(Builder $query): void
     {
-        $query
-            ->published()
-            ->where('is_on_view', true);
+        $query->published()->onView()->translated();
+    }
+
+    public function scopeNotActive(Builder $query): void
+    {
+        $query->where('published', false)
+            ->orWhere->offView()
+            ->orWhere->missingTranslations();
+    }
+
+    public function scopeTranslated(Builder $query): void
+    {
+        $query->whereDoesntHave('translations', fn (Builder $query) => $query->where('active', false));
+    }
+
+    public function scopeMissingTranslations(Builder $query): void
+    {
+        $query->whereHas('translations', fn (Builder $query) => $query->where('active', false));
+    }
+
+    public function scopeOnView(Builder $query): void
+    {
+        $query->where('is_on_view', true);
+    }
+
+    public function scopeOffView(Builder $query): void
+    {
+        $query->where('is_on_view', false);
     }
 
     /**

--- a/app/Models/Theme.php
+++ b/app/Models/Theme.php
@@ -94,7 +94,7 @@ class Theme extends Model implements Sortable
     protected static function booted(): void
     {
         static::addGlobalScope('order', function (Builder $builder) {
-            $builder->orderBy('position');
+            $builder->orderBy((new static)->getTable() . '.position');
         });
     }
 

--- a/app/Models/ThemePrompt.php
+++ b/app/Models/ThemePrompt.php
@@ -30,7 +30,7 @@ class ThemePrompt extends Model implements Sortable
     protected static function booted(): void
     {
         static::addGlobalScope('order', function (Builder $builder) {
-            $builder->orderBy('position');
+            $builder->orderBy((new static)->getTable() . '.position');
         });
     }
 

--- a/app/Models/ThemePromptArtwork.php
+++ b/app/Models/ThemePromptArtwork.php
@@ -34,7 +34,7 @@ class ThemePromptArtwork extends Model implements Sortable
     protected static function booted(): void
     {
         static::addGlobalScope('order', function (Builder $builder) {
-            $builder->orderBy('position');
+            $builder->orderBy((new static)->getTable() . '.position');
         });
     }
 

--- a/app/Repositories/ArtworkRepository.php
+++ b/app/Repositories/ArtworkRepository.php
@@ -49,4 +49,24 @@ class ArtworkRepository extends ModuleRepository
 
         return parent::prepareFieldsBeforeCreate([...$fields, ...$apiFields, ...$translatedFields]);
     }
+
+    public function getCountVisible(): int
+    {
+        return $this->model->active()->count();
+    }
+
+    public function getCountHidden(): int
+    {
+        return $this->model->notActive()->count();
+    }
+
+    public function getCountOnView(): int
+    {
+        return $this->model->onView()->count();
+    }
+
+    public function getCountOffView(): int
+    {
+        return $this->model->offView()->count();
+    }
 }


### PR DESCRIPTION
This PR adds filtering to artwork and cleans up theme quick filters.

<img width="1375" alt="Screenshot 2024-04-30 at 10 05 03 PM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/6413be03-7ed9-429d-bc36-3aeddcef3869">
<img width="774" alt="Screenshot 2024-04-30 at 10 05 16 PM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/ecdaf859-1f03-454d-a36d-ee9817c3f005">
<img width="788" alt="Screenshot 2024-04-30 at 10 05 26 PM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/4d47600c-bab2-40db-be5e-0cd76d9b5338">
