### PR TITLE
Fix API image URL

### DIFF
--- a/app/Http/Resources/ThemePromptArtworkResource.php
+++ b/app/Http/Resources/ThemePromptArtworkResource.php
@@ -97,7 +97,7 @@ class ThemePromptArtworkResource extends JsonResource
             'img_medium' => static::IMAGE_SIZES['medium'],
             'img_large' => static::IMAGE_SIZES['large'],
         ])->map(fn ($size) => [
-            'url' => $this->getApiImageUrl($artwork->id, $size),
+            'url' => $this->getApiImageUrl($artwork->image_id, $size),
             ...$this->getDimensions(
                 $artwork->thumbnail->width,
                 $artwork->thumbnail->height,


### PR DESCRIPTION
This PR fixes an issue with the image URL generation.

Need to pass the artwork's `image_id` instead of the artwork `id`.