### PR TITLE
Update artwork `img` to be a medium size 

### DIFF
--- a/app/Http/Resources/ThemePromptArtworkResource.php
+++ b/app/Http/Resources/ThemePromptArtworkResource.php
@@ -9,9 +9,9 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class ThemePromptArtworkResource extends JsonResource
 {
     public const IMAGE_SIZES = [
-        'img' => 843,
-        'small' => 200,
-        'medium' => 843,
+        'img' => 1686,
+        'small' => 1686,
+        'medium' => 1686,
         'large' => 1686,
     ];
 

--- a/app/Http/Resources/ThemePromptArtworkResource.php
+++ b/app/Http/Resources/ThemePromptArtworkResource.php
@@ -9,7 +9,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class ThemePromptArtworkResource extends JsonResource
 {
     public const IMAGE_SIZES = [
-        'img' => 3000,
+        'img' => 843,
         'small' => 200,
         'medium' => 843,
         'large' => 1686,


### PR DESCRIPTION
This PR updates the output artwork's `img` from it's original size to a medium size.
This size is used on the client and is most likely to be cached.