### PR TITLE
Add spot checking to input sources when seeding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^7.0",
         "phpunit/phpunit": "^10.1",
+        "sapientpro/image-comparator": "^1.0",
         "spatie/laravel-ignition": "^2.0",
         "spatie/ray": "^1.41"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5326c2eea1ede2677311a69dd4d30ce",
+    "content-hash": "79f343208365d88771a4cff909fb1e49",
     "packages": [
         {
             "name": "area17/twill",
@@ -9773,6 +9773,52 @@
                 }
             ],
             "time": "2024-04-05T04:39:01+00:00"
+        },
+        {
+            "name": "sapientpro/image-comparator",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sapientpro/image-comparator.git",
+                "reference": "19219b83f4a729e29baae2c490bb8f032cb2d0d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sapientpro/image-comparator/zipball/19219b83f4a729e29baae2c490bb8f032cb2d0d7",
+                "reference": "19219b83f4a729e29baae2c490bb8f032cb2d0d7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "10.0.0",
+                "squizlabs/php_codesniffer": "3.7.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SapientPro\\ImageComparator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "SapientPro",
+                    "email": "info@sapient.pro",
+                    "homepage": "https://sapient.pro/"
+                }
+            ],
+            "description": "Compare images using PHP",
+            "support": {
+                "issues": "https://github.com/sapientpro/image-comparator/issues",
+                "source": "https://github.com/sapientpro/image-comparator/tree/v1.0.1"
+            },
+            "time": "2023-04-27T07:54:28+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
This PR adds some spot-checking of translations to the seeding script. 

This validates the assumption that themes, prompts, and artwork appear in the same order for the 3 translation sources. 

Potential issues are displayed for further validation.

```
Artwork 443 Img:http://journeymaker.artic.edu//sites/default/files/207740.jpg
ES Artwork 1070 Img:http://journeymaker.artic.edu//sites/default/files/RomanEmperor.jpg
Similarity: 28
```

Each block starts with the main object followed by the translation being compared.

In the example above in the `data.json` file there is an artwork with an ID of 443 that has an image of http://journeymaker.artic.edu//sites/default/files/207740.jpg.  We are mapping this to the Spanish language file (`data-es.json`) where the artwork ID 1070 has an image of http://journeymaker.artic.edu//sites/default/files/RomanEmperor.jpg.

If we compare the two images we can see these two artworks are referencing the same object:
<img width="1154" alt="Screenshot 2024-05-02 at 12 09 52 PM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/83799f68-dec0-4096-b495-8ab9c4e701dd">

Sometimes a translation file will be missing image information:

```
Artwork 642 Img:http://journeymaker.artic.edu//sites/default/files/220272.jpg
ZH Artwork 1644 Img:
Similarity: 0
```