### PR TITLE
Move `sapientpro/image-comparator` to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
-        "laravel/tinker": "^2.8"
+        "laravel/tinker": "^2.8",
+        "sapientpro/image-comparator": "^1.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
@@ -20,7 +21,6 @@
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^7.0",
         "phpunit/phpunit": "^10.1",
-        "sapientpro/image-comparator": "^1.0",
         "spatie/laravel-ignition": "^2.0",
         "spatie/ray": "^1.41"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79f343208365d88771a4cff909fb1e49",
+    "content-hash": "18a2b8cd7e16cc3172b21cc7d62a1f76",
     "packages": [
         {
             "name": "area17/twill",
@@ -5705,6 +5705,52 @@
             "time": "2023-11-08T05:53:05+00:00"
         },
         {
+            "name": "sapientpro/image-comparator",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sapientpro/image-comparator.git",
+                "reference": "19219b83f4a729e29baae2c490bb8f032cb2d0d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sapientpro/image-comparator/zipball/19219b83f4a729e29baae2c490bb8f032cb2d0d7",
+                "reference": "19219b83f4a729e29baae2c490bb8f032cb2d0d7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "10.0.0",
+                "squizlabs/php_codesniffer": "3.7.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SapientPro\\ImageComparator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "SapientPro",
+                    "email": "info@sapient.pro",
+                    "homepage": "https://sapient.pro/"
+                }
+            ],
+            "description": "Compare images using PHP",
+            "support": {
+                "issues": "https://github.com/sapientpro/image-comparator/issues",
+                "source": "https://github.com/sapientpro/image-comparator/tree/v1.0.1"
+            },
+            "time": "2023-04-27T07:54:28+00:00"
+        },
+        {
             "name": "spatie/laravel-activitylog",
             "version": "4.8.0",
             "source": {
@@ -9773,52 +9819,6 @@
                 }
             ],
             "time": "2024-04-05T04:39:01+00:00"
-        },
-        {
-            "name": "sapientpro/image-comparator",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sapientpro/image-comparator.git",
-                "reference": "19219b83f4a729e29baae2c490bb8f032cb2d0d7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sapientpro/image-comparator/zipball/19219b83f4a729e29baae2c490bb8f032cb2d0d7",
-                "reference": "19219b83f4a729e29baae2c490bb8f032cb2d0d7",
-                "shasum": ""
-            },
-            "require": {
-                "ext-gd": "*",
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "10.0.0",
-                "squizlabs/php_codesniffer": "3.7.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "SapientPro\\ImageComparator\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "SapientPro",
-                    "email": "info@sapient.pro",
-                    "homepage": "https://sapient.pro/"
-                }
-            ],
-            "description": "Compare images using PHP",
-            "support": {
-                "issues": "https://github.com/sapientpro/image-comparator/issues",
-                "source": "https://github.com/sapientpro/image-comparator/tree/v1.0.1"
-            },
-            "time": "2023-04-27T07:54:28+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
This PR moves `sapientpro/image-comparator` to require to allow seeders to run in production. 