### PR TITLE
Small Fixes

### DIFF
--- a/app/Http/Controllers/Twill/ArtworkController.php
+++ b/app/Http/Controllers/Twill/ArtworkController.php
@@ -84,7 +84,8 @@ class ArtworkController extends ModuleController
                             ->label('Override Image')
                             ->note('This will replace the image above'),
                         Input::make()
-                            ->name('artist'),
+                            ->name('artist')
+                            ->translatable(),
                         Input::make()
                             ->type('textarea')
                             ->name('location_directions')

--- a/app/Http/Controllers/Twill/ThemePromptController.php
+++ b/app/Http/Controllers/Twill/ThemePromptController.php
@@ -111,8 +111,8 @@ class ThemePromptController extends ModuleController
                                 Input::make()
                                     ->type('textarea')
                                     ->name('viewing_description')
-                                    ->maxLength(125 + 10)
-                                    ->note('Limit is 125 characters + 10 for padding.')
+                                    ->maxLength(110 + 10)
+                                    ->note('Limit is 110 characters + 10 for padding.')
                                     ->label('Look Again (Journey Guide)')
                                     ->translatable(),
                                 Select::make()

--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -157,7 +157,7 @@ class Artwork extends Model
     public function defaultCmsImage($params = [])
     {
         // If requesting a thumbnail, return the thumbnail image
-        if ($params = ['w' => 100, 'h' => 100]) {
+        if ($params == ['w' => 100, 'h' => 100]) {
             return $this->image('override', 'thumbnail', $params, false, true, $this->medias->first());
         }
 

--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -154,6 +154,22 @@ class Artwork extends Model
         $query->where('is_on_view', false);
     }
 
+    public function defaultCmsImage($params = [])
+    {
+        // If requesting a thumbnail, return the thumbnail image
+        if ($params = ['w' => 100, 'h' => 100]) {
+            return $this->image('override', 'thumbnail', $params, false, true, $this->medias->first());
+        }
+
+        $media = $this->medias->first();
+
+        if ($media) {
+            return $this->image(null, null, $params, true, true, $media) ?? ImageService::getTransparentFallbackUrl();
+        }
+
+        return ImageService::getTransparentFallbackUrl();
+    }
+
     /**
      * Returns the URL of the attached image for a role and crop.
      */

--- a/config/twill.php
+++ b/config/twill.php
@@ -19,7 +19,7 @@ return [
                 'activity' => true,
                 'draft' => true,
                 'search' => true,
-                'search_fields' => ['title', 'artist'],
+                'search_fields' => ['title', 'artist', 'datahub_id'],
             ],
         ],
     ],


### PR DESCRIPTION
This PR addresses a couple of issues:
- Fixes issue with artist name missing translatable
- Allow searching for artwork by `datahub_id`
- Adjusts the Look Again limits and help text
- Fixes artwork thumbnails when used within the CMS

<img width="1117" alt="Screenshot 2024-05-09 at 11 47 27 AM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/39ddd524-c1cd-43f4-ab39-a48f78d1333b">
<img width="1127" alt="Screenshot 2024-05-09 at 11 47 34 AM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/0014b948-6dd1-4ecc-8b34-925a4841ce64">
