### PR TITLE
Include additional on/off view context on Directory

### DIFF
--- a/app/Models/ThemePrompt.php
+++ b/app/Models/ThemePrompt.php
@@ -8,6 +8,7 @@ use A17\Twill\Models\Behaviors\HasTranslation;
 use A17\Twill\Models\Behaviors\Sortable;
 use A17\Twill\Models\Model;
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class ThemePrompt extends Model implements Sortable
@@ -49,5 +50,15 @@ class ThemePrompt extends Model implements Sortable
         $query
             ->published()
             ->whereDoesntHave('translations', fn (Builder $query) => $query->where('active', false));
+    }
+
+    protected function onJourneyMaker(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->published
+                && $this->translations->reject(fn ($translation) => $translation->active)->isEmpty()
+                && $this->theme->published
+                && $this->theme->translations->reject(fn ($translation) => $translation->active)->isEmpty(),
+        );
     }
 }

--- a/public/assets/twill/css/custom.css
+++ b/public/assets/twill/css/custom.css
@@ -284,6 +284,11 @@ ol,
   margin-bottom: 0.25rem;
 }
 
+.custom :is(.my-4) {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
 .custom :is(.mb-1) {
   margin-bottom: 0.25rem;
 }
@@ -360,6 +365,10 @@ ol,
   display: none;
 }
 
+.custom :is(.h-1) {
+  height: 0.25rem;
+}
+
 .custom :is(.h-12) {
   height: 3rem;
 }
@@ -422,6 +431,14 @@ ol,
 
 .custom :is(.cursor-pointer) {
   cursor: pointer;
+}
+
+.custom :is(.list-inside) {
+  list-style-position: inside;
+}
+
+.custom :is(.list-disc) {
+  list-style-type: disc;
 }
 
 .custom :is(.grid-cols-2) {
@@ -504,6 +521,10 @@ ol,
 
 .custom :is(.rounded-md) {
   border-radius: 0.375rem;
+}
+
+.custom :is(.\!border-2) {
+  border-width: 2px !important;
 }
 
 .custom :is(.border) {

--- a/public/assets/twill/css/custom.css
+++ b/public/assets/twill/css/custom.css
@@ -284,11 +284,6 @@ ol,
   margin-bottom: 0.25rem;
 }
 
-.custom :is(.my-4) {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-}
-
 .custom :is(.mb-1) {
   margin-bottom: 0.25rem;
 }
@@ -365,10 +360,6 @@ ol,
   display: none;
 }
 
-.custom :is(.h-1) {
-  height: 0.25rem;
-}
-
 .custom :is(.h-12) {
   height: 3rem;
 }
@@ -431,14 +422,6 @@ ol,
 
 .custom :is(.cursor-pointer) {
   cursor: pointer;
-}
-
-.custom :is(.list-inside) {
-  list-style-position: inside;
-}
-
-.custom :is(.list-disc) {
-  list-style-type: disc;
 }
 
 .custom :is(.grid-cols-2) {
@@ -521,10 +504,6 @@ ol,
 
 .custom :is(.rounded-md) {
   border-radius: 0.375rem;
-}
-
-.custom :is(.\!border-2) {
-  border-width: 2px !important;
 }
 
 .custom :is(.border) {

--- a/resources/views/admin/directory.blade.php
+++ b/resources/views/admin/directory.blade.php
@@ -6,10 +6,6 @@
 
 @section('customPageContent')
     <div class="custom">
-        <p class="text-sm">
-            ✅ / ❌ indicates the artwork is on or off view. For artwork to appear in JourneyMaker it must be on view, not in Regenstein Hall, have all translations, and be published.
-        </p>
-        <hr class="my-4 !border-2">
         @foreach($themes as $theme)
             <div class="mb-8" x-data="{open: false}">
                 <div class="flex items-center gap-4">
@@ -52,8 +48,9 @@
                                                         <br><small class="text-xs text-gray-400">{{ $artwork->artwork->artist }}</small>
                                                     </a>
                                                 </td>
-                                                <td class="px-3 py-4 text-sm" title="{{ $artwork->artwork->is_on_view? 'On View' : 'Off View' }}">
-                                                    {{ $artwork->artwork->is_on_view? '✅' : '❌' }}
+                                                <td class="px-3 py-4 text-sm" title="{{ $artwork->artwork->on_journey_maker? 'On JourneyMaker' : 'Not On JourneyMaker' }}">
+                                                    {{ $artwork->artwork->on_journey_maker? '✅' : '❌' }}
+                                                    {{ $artwork->artwork->off_journey_maker_reasons }}
                                                 </td>
                                             </tr>
                                         @endforeach

--- a/resources/views/admin/directory.blade.php
+++ b/resources/views/admin/directory.blade.php
@@ -6,6 +6,10 @@
 
 @section('customPageContent')
     <div class="custom">
+        <p class="text-sm">
+            ✅ / ❌ indicates the artwork is on or off view. For artwork to appear in JourneyMaker it must be on view, have all translations, and not be in Regenstein Hall.
+        </p>
+        <hr class="my-4 !border-2">
         @foreach($themes as $theme)
             <div class="mb-8" x-data="{open: false}">
                 <div class="flex items-center gap-4">

--- a/resources/views/admin/directory.blade.php
+++ b/resources/views/admin/directory.blade.php
@@ -7,7 +7,7 @@
 @section('customPageContent')
     <div class="custom">
         <p class="text-sm">
-            ✅ / ❌ indicates the artwork is on or off view. For artwork to appear in JourneyMaker it must be on view, have all translations, and not be in Regenstein Hall.
+            ✅ / ❌ indicates the artwork is on or off view. For artwork to appear in JourneyMaker it must be on view, not in Regenstein Hall, have all translations, and be published.
         </p>
         <hr class="my-4 !border-2">
         @foreach($themes as $theme)


### PR DESCRIPTION
This PR adds additional context to the on/off view column on the artwork directory:

<img width="1183" alt="Screenshot 2024-05-17 at 2 49 35 PM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/bfa56036-de7f-48ab-9142-ec28ec23d916">

