### PR TITLE
Return default `null` artwork when missing `datahub_id`

### DIFF
--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -269,6 +269,10 @@ class Artwork extends Model
             array_pad([], count(Artwork::ARTWORK_API_FIELDS), null)
         );
 
+        if (! $this->datahub_id) {
+            return $nullArtwork;
+        }
+
         return $this->getApiData(
             self::ARTWORK_API_FIELDS,
             "/api/v1/artworks/{$this->datahub_id}",


### PR DESCRIPTION
Sometimes Twill will instantiate an empty model. In these cases we do not want to query the API. 