### PR TITLE
Fix issues with seeded data

### DIFF
--- a/app/Repositories/ArtworkRepository.php
+++ b/app/Repositories/ArtworkRepository.php
@@ -44,16 +44,14 @@ class ArtworkRepository extends ModuleRepository
             $apiFields['floor'] = $galleryFields['floor'] ?? null;
         }
 
-        $artist = Str::of($apiFields['artist_title'] ?: $apiFields['artist_display'])
-            ->before("\n")->trim()->__toString();
+        if (! data_get($fields, "artist.en")) {
+            $artist = Str::of($apiFields['artist_title'] ?: $apiFields['artist_display'])
+                ->before("\n")->trim()->__toString();
 
-        $translatedFields = [
-            'artist' => [
-                'en' => $artist,
-            ],
-        ];
+            data_set($fields, "artist.en", $artist);
+        }
 
-        return parent::prepareFieldsBeforeCreate([...$fields, ...$apiFields, ...$translatedFields]);
+        return parent::prepareFieldsBeforeCreate([...$fields, ...$apiFields]);
     }
 
     public function afterSave(TwillModelContract $model, array $fields): void

--- a/database/seeders/ArtworkSeeder.php
+++ b/database/seeders/ArtworkSeeder.php
@@ -45,7 +45,7 @@ class ArtworkSeeder extends Seeder
                 'en' => [
                     'title' => $rawArtwork['title'],
                     'artist' => $rawArtwork['artist'],
-                    'location_directions' => $rawArtwork['locationDirections'] ?? null,
+                    'locationDirections' => $rawArtwork['locationDirections'] ?? null,
                 ],
             ])->merge($rawArtwork['translations'])->map(
                 fn ($translation, $locale) => [
@@ -70,9 +70,9 @@ class ArtworkSeeder extends Seeder
 
             $themePromptArtworkData = collect([
                 'en' => [
-                    'detail_narrative' => $rawArtwork['detailNarrative'] ?? null,
-                    'viewing_description' => $rawArtwork['viewingDescription'] ?? null,
-                    'activity_instructions' => $rawArtwork['activityInstructions'] ?? null,
+                    'detailNarrative' => $rawArtwork['detailNarrative'] ?? null,
+                    'viewingDescription' => $rawArtwork['viewingDescription'] ?? null,
+                    'activityInstructions' => $rawArtwork['activityInstructions'] ?? null,
                 ],
             ])->merge($rawArtwork['translations'])->map(
                 fn ($translation, $locale) => [


### PR DESCRIPTION
This PR fixes an issue with English language activity and Spanish and Mandarin artist names.

## Problem 1

**We're not seeing English language activity text:** Both in the CMS and the FE, English language activity text (eg detailNarrative, lookAgain, and activityTemplate) isn't being correctly pulled in. Spanish and Mandarin content is working without issue. 

From nikhil: "It appears that the seeders are not pulling that data in from the current production JSON files. I wonder if something is going awry with the English translations here: [https://github.com/art-institute-of-chicago/journeymaker-cms/blob/develop/database/seeders/ArtworkSeeder.php#L71-L85](https://github.com/art-institute-of-chicago/journeymaker-cms/blob/develop/database/seeders/ArtworkSeeder.php#L71-L85)"

### Solution

nikhil correctly pointed out the source of the issue. When merging the English values with the translated values, I used the incorrect `snake_casing` when I should have built the English array using the same `camelCasing` as the translations. This bug affected the detail narrative, viewing description, activity instructions, and location directions.
## Problem 2

**We also do not see Spanish and Mandarin artist names:** Similar, but different! Again, in both the CMS and the FE, the Spanish and Mandarin artist names aren't being pulled from the JSON. Within the CMS these fields are just blank, and then on the FE they render as `null`.

### Solution

This one was more tricky. The artist's name appears in both the Spanish and Mandarin data. When the data is passed to `ArtworkRepository::firstOrCreate` it calls `prepareFieldsBeforeCreate`, which was setting $translatedFields.

```
$translatedFields = [
    'artist' => [
        'en' => $artist,
    ],
];
```

This bug was introduced in [PR #40](https://github.com/art-institute-of-chicago/journeymaker-cms/pull/40), updating seeders to add revisions and activity. Before this the `ArtworkRepository` was not used during the seeding process.