### PR TITLE
Allow CMS title to be overridden

### DIFF
--- a/app/Http/Controllers/Twill/ArtworkController.php
+++ b/app/Http/Controllers/Twill/ArtworkController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Twill;
 use A17\Twill\Http\Controllers\Admin\ModuleController;
 use A17\Twill\Models\Contracts\TwillModelContract;
 use A17\Twill\Services\Forms\BladePartial;
+use A17\Twill\Services\Forms\Fields\Checkbox;
 use A17\Twill\Services\Forms\Fields\Input;
 use A17\Twill\Services\Forms\Fields\Medias;
 use A17\Twill\Services\Forms\Fieldset;
@@ -72,8 +73,12 @@ class ArtworkController extends ModuleController
                     ->fields([
                         Input::make()
                             ->name('title')
+                            ->label('CMS Title')
                             ->maxLength(255)
                             ->translatable(),
+                        Checkbox::make()
+                            ->name('use_api_title')
+                            ->label('Use API Title: '.$apiArtwork->title ?? ''),
                         BladePartial::make()
                             ->view('forms.image')
                             ->withAdditionalParams([
@@ -96,6 +101,7 @@ class ArtworkController extends ModuleController
                         BladePartial::make()
                             ->view('forms.object-info')
                             ->withAdditionalParams([
+                                'title' => $apiArtwork->title ?? '',
                                 'isOnView' => $model->is_on_view ?? false,
                                 'datahubId' => $model->datahub_id ?? '',
                                 'mainReferenceNumber' => $apiArtwork->main_reference_number ?? '',
@@ -141,7 +147,7 @@ class ArtworkController extends ModuleController
             )
             ->add(Text::make()
                 ->field('gallery_name')
-                ->customRender(fn ($artwork) => $artwork->gallery_name . '' ?? ''))
+                ->customRender(fn ($artwork) => $artwork->gallery_name.'' ?? ''))
             ->add(Text::make()
                 ->field('Themes')
                 ->customRender(fn ($artwork) => $artwork->themePrompts()->with('theme')->get()->pluck('theme')

--- a/app/Repositories/ArtworkRepository.php
+++ b/app/Repositories/ArtworkRepository.php
@@ -35,7 +35,7 @@ class ArtworkRepository extends ModuleRepository
             ->except('title')
             ->toArray();
 
-        if ($apiFields['is_on_view'] === true) {
+        if ($apiFields['is_on_view'] === true && $apiFields['gallery_id']) {
             $galleryFields = $this->api
                 ->get(endpoint: '/api/v1/galleries/'.$apiFields['gallery_id'])
                 ->map(fn ($gallery) => (array) $gallery)

--- a/app/Repositories/ArtworkRepository.php
+++ b/app/Repositories/ArtworkRepository.php
@@ -28,9 +28,12 @@ class ArtworkRepository extends ModuleRepository
     public function prepareFieldsBeforeCreate(array $fields): array
     {
         $apiFields = $this->api
-            ->get(Artwork::ARTWORK_API_FIELDS, '/api/v1/artworks/'.$fields['datahub_id'])
-            ->map(fn ($artwork) => (array) $artwork)
-            ->first();
+            ->get(endpoint: '/api/v1/artworks/'.$fields['datahub_id'])
+            ->map(fn ($artwork) => collect((array) $artwork))
+            ->first()
+            ->only(Artwork::ARTWORK_API_FIELDS)
+            ->except('title')
+            ->toArray();
 
         if ($apiFields['is_on_view'] === true) {
             $galleryFields = $this->api

--- a/database/migrations/2024_06_26_191626_add_use_api_title_to_artworks_table.php
+++ b/database/migrations/2024_06_26_191626_add_use_api_title_to_artworks_table.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('artworks', function (Blueprint $table) {
+            $table->boolean('use_api_title')->default(true)->after('datahub_id');
+        });
+    }
+};

--- a/resources/views/forms/object-info.blade.php
+++ b/resources/views/forms/object-info.blade.php
@@ -5,6 +5,10 @@
 @php
     $items = [
         [
+            'label' => 'API Title',
+            'value' => $title
+        ],
+        [
             'label' => 'Is On View',
             'value' => $isOnView ? '✅' : '❌'
         ],


### PR DESCRIPTION
This PR addresses a workflow issue involving artwork titles.

> [!IMPORTANT]  
> This PR includes a migration.

## Problem

We've been seeing a disconnect between when our curators in CITI update the styling of artwork titles (which is reflected in the API) and how those artwork titles appear in the JourneyMaker CMS/FE. We want those titles to update along with API changes unless manually overridden, but that's not the case. 

From nikhil:  

> For example, the image field displays the API image on the CMS form and allows you to upload a new image to override. The title field, however, is baked into any local Twill object—every entity has a title. So the title gets pulled from the API when you create an Artwork object and is stored locally. From then on, we will always reference the local title field entered in the CMS.  
> I think we might need to add a checkbox to the artwork below the title field that says something like “Use CMS title instead of API title” and add logic wherever we reference an artwork title to look at this checkbox and decide whether to get the title from the API or use the title as entered in the CMS.

> [!NOTE]  
> The API only provides the title in English, so the Twill title will **always** be used for the other two languages.

### Solution

A new checkbox has been added to the artwork screen:
<img width="974" alt="Screenshot 2024-06-26 at 2 51 31 PM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/072c2886-8fb6-4f08-a5e5-395178498571">

Having the checkbox as opt-in (but defaults to in) allows the label to indicate the result and display the current API title.

Additionally, the API title has been added to the information listed at the bottom of the page.

<img width="490" alt="Screenshot 2024-06-26 at 2 51 44 PM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/2e19430d-73c3-4013-ab4e-ee9edd8ac73c">

The choice is also used throughout the other parts of the UI such as search.

**Using the API title:**

<img width="990" alt="Screenshot 2024-06-26 at 2 52 46 PM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/5af81050-346a-48d9-a459-f22a4d800d3f">

**Using the CMS title:**

<img width="979" alt="Screenshot 2024-06-26 at 2 53 11 PM" src="https://github.com/art-institute-of-chicago/journeymaker-cms/assets/194221/108aec06-2b5f-4c28-b014-c8dd29940957">


